### PR TITLE
Fix desktop file command

### DIFF
--- a/com.skype.Client.json
+++ b/com.skype.Client.json
@@ -45,7 +45,7 @@
                         "mv usr/* .",
                         "rmdir usr",
                         "mkdir -p export/share/applications",
-                        "sed -e 's/Icon=skypeforlinux/Icon=com.skype.Client/' -e 's$/usr/bin/skypeforlinux/$/app/bin/skype$' share/applications/skypeforlinux.desktop > export/share/applications/com.skype.Client.desktop",
+                        "sed -e 's/Icon=skypeforlinux/Icon=com.skype.Client/' -e 's$/usr/bin/skypeforlinux$/app/bin/skype$' share/applications/skypeforlinux.desktop > export/share/applications/com.skype.Client.desktop",
                         "echo StartupWMClass=SkypeAlpha >> export/share/applications/com.skype.Client.desktop",
                         "mkdir -p export/share/icons/hicolor/256x256/apps",
                         "cp share/icons/hicolor/256x256/apps/skypeforlinux.png export/share/icons/hicolor/256x256/apps/com.skype.Client.png"


### PR DESCRIPTION
Starting skype from gnome shell didn't work, since the command in the desktop file was wrong. This is a small fix for the sed substitution.