### PR TITLE
Fix link to Debian package

### DIFF
--- a/com.skype.Client.json
+++ b/com.skype.Client.json
@@ -125,9 +125,9 @@
                 {
                     "type": "extra-data",
                     "filename": "skypeforlinux-64.deb",
-                    "url": "https://repo.skype.com/latest/skypeforlinux-64.deb",
-                    "sha256": "d09152d1eabd57d75346eda8ab91ddb8c48d275a292ae5a2f18e179ccadc2bb7",
-                    "size": 66668854
+                    "url": "https://repo.skype.com/deb/pool/main/s/skypeforlinux/skypeforlinux_8.10.0.4_amd64.deb",
+                    "sha256": "af44e235fa5674290fae984586e970314140dc286fdaed91d16d35837dc76ee7",
+                    "size": 66964950
                 }
             ],
             "build-commands": [


### PR DESCRIPTION
The build manifest points to the always "latest" Debian package and so the size and SHA256 hash of the file changes when the "latest" link  changes. Fix this by using a fixed version of the package. This change uses Skype 8.10.0.4, the version "latest" currently points to.

Fixes #6.