### PR TITLE
Patch to work with freedesktop 18.08

### DIFF
--- a/com.skype.Client.json
+++ b/com.skype.Client.json
@@ -1,10 +1,10 @@
 {
     "app-id": "com.skype.Client",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "unstable",
+    "runtime-version": "18.08",
     "base": "io.atom.electron.BaseApp",
-    "base-version": "stable",
-    "branch": "stable",
+    "base-version": "18.08",
+    "branch": "18.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "skype",
     "separate-locales": false,

--- a/com.skype.Client.json
+++ b/com.skype.Client.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.skype.Client",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "1.6",
+    "runtime-version": "unstable",
     "base": "io.atom.electron.BaseApp",
     "base-version": "stable",
     "branch": "stable",
@@ -135,7 +135,7 @@
                 "install skype.sh /app/bin/skype",
                 "install -Dm644 com.skype.Client.appdata.xml /app/share/appdata/com.skype.Client.appdata.xml",
                 "cp /usr/bin/ar /app/bin",
-                "cp /usr/lib/libbfd-*.so /app/lib"
+                "ARCH_TRIPLE=$(gcc --print-multiarch) && cp /usr/lib/${ARCH_TRIPLE}/libbfd-*.so /app/lib"
             ]
         }
     ]


### PR DESCRIPTION
Freedesktop 18.08 works with multi-arch, so libraries are split out,
and libbfd has moved. This patch updates the copying of libbfd to
the new multi-arch system.

Obviously don't merge until freedesktop released as stable

Note: this is not backwards compatible with freedesktop 1.6 as /usr/lib/{multiarch-triple}/libbfd.so doesn't exist in 1.6