### PR TITLE
Switch base app to org.electronjs.Electron2.BaseApp

### DIFF
--- a/com.skype.Client.json
+++ b/com.skype.Client.json
@@ -2,7 +2,7 @@
     "app-id": "com.skype.Client",
     "runtime": "org.freedesktop.Platform",
     "runtime-version": "1.6",
-    "base": "io.atom.electron.BaseApp",
+    "base": "org.electronjs.Electron2.BaseApp",
     "base-version": "stable",
     "branch": "stable",
     "sdk": "org.freedesktop.Sdk",
@@ -63,7 +63,6 @@
                 }
             ]
         },
-        "shared-modules/udev/udev-175.json",
         {
             "name": "v4l-utils",
             "config-opts": [


### PR DESCRIPTION
Skype is now an Electron 2.x.x app. This patch changes the base app accordingly and removes the now redundant dependency on udev. It also makes the pull request #45 irrelevant, as the new base app already includes libappindicator-gtk3.