### PR TITLE
Update to 8.33.0.41, without crashing.

### DIFF
--- a/com.skype.Client.json
+++ b/com.skype.Client.json
@@ -20,6 +20,8 @@
         /* It seems to call NM and bluez */
         "--system-talk-name=org.freedesktop.NetworkManager",
         "--system-talk-name=org.bluez",
+        /* It crashes if it can't call Inhibit on logind */
+        "--system-talk-name=org.freedesktop.login1",
         /* File system access */
         "--filesystem=xdg-download",
         "--filesystem=home:ro",

--- a/com.skype.Client.json
+++ b/com.skype.Client.json
@@ -127,9 +127,9 @@
                 {
                     "type": "extra-data",
                     "filename": "skypeforlinux-64.deb",
-                    "url": "https://repo.skype.com/deb/pool/main/s/skypeforlinux/skypeforlinux_8.29.0.50_amd64.deb",
-                    "sha256": "ae78d24115c29ff8e7e215ae561b681537194fb1997048ff2275ff9f807eb95a",
-                    "size": 73251932
+                    "url": "https://repo.skype.com/deb/pool/main/s/skypeforlinux/skypeforlinux_8.33.0.41_amd64.deb",
+                    "sha256": "bda45e1a5a60c5a1c8347eeb7ad9077925cda4d33d822a123ab7edee48aca878",
+                    "size": 73356304
                 }
             ],
             "build-commands": [


### PR DESCRIPTION
On startup, Skype calls org.freedesktop.login1.Manager.Inhibit, and crashes if the method call returns an error rather than success.

I got the idea from [this forum thread][0] from a Slackware user who doesn't have logind, and checked it via through the medium of --socket=system-bus (it worked) + Bustle (to check what it talks to).

[0]: https://answers.microsoft.com/en-us/skype/forum/skype_linux-skype_startms-skype_installms/skype-for-linux-820xx-doesnt-start-on-debian-910/67ebd445-12d3-479c-af49-2ffd7299d20d