### PR TITLE
Run Electron with --no-sandbox

### DIFF
--- a/com.skype.Client.json
+++ b/com.skype.Client.json
@@ -97,6 +97,7 @@
                         "rm -f control.tar.gz data.tar.xz debian-binary",
                         "mv usr/* .",
                         "rmdir usr",
+                        "patch-resources share/skypeforlinux/resources/app.asar",
                         "mkdir -p export/share/applications",
                         "sed -e 's/Icon=skypeforlinux/Icon=com.skype.Client/' -e 's$/usr/bin/skypeforlinux$/app/bin/skype$' share/applications/skypeforlinux.desktop > export/share/applications/com.skype.Client.desktop",
                         "echo StartupWMClass=SkypeAlpha >> export/share/applications/com.skype.Client.desktop",
@@ -110,12 +111,16 @@
                     "commands": [
                         "SKYPE_LOGS=$XDG_CONFIG_HOME/logs",
                         "mkdir -p $SKYPE_LOGS",
-                        "nohup env TMPDIR=$XDG_CACHE_HOME /app/extra/share/skypeforlinux/skypeforlinux --executed-from=\"$(pwd)\" --pid=$$ \"$@\" > \"$SKYPE_LOGS/skype-startup.log\" 2>&1 &"
+                        "nohup env TMPDIR=$XDG_CACHE_HOME /app/extra/share/skypeforlinux/skypeforlinux --no-sandbox --executed-from=\"$(pwd)\" --pid=$$ \"$@\" > \"$SKYPE_LOGS/skype-startup.log\" 2>&1 &"
                     ]
                 },
                 {
                     "type": "file",
                     "path": "com.skype.Client.appdata.xml"
+                },
+                {
+                    "type": "file",
+                    "path": "patch-resources.py"
                 },
                 {
                     "type": "extra-data",
@@ -139,6 +144,7 @@
                 "install apply_extra /app/bin",
                 "install skype.sh /app/bin/skype",
                 "install -Dm644 com.skype.Client.appdata.xml /app/share/appdata/com.skype.Client.appdata.xml",
+                "install -Dm755 patch-resources.py /app/bin/patch-resources",
                 "cp /usr/bin/ar /app/bin",
                 "ARCH_TRIPLE=$(gcc --print-multiarch) && cp /usr/lib/${ARCH_TRIPLE}/libbfd-*.so /app/lib"
             ]

--- a/patch-resources.py
+++ b/patch-resources.py
@@ -1,0 +1,63 @@
+#!/usr/bin/python3
+
+# patch-resources will patch the Skype resources file to allow us to disable the
+# sandbox on the command line, as a temporary workaround for
+# https://github.com/flathub/com.skype.Client/issues/70
+
+# The resources file is, as other Electron apps, an asar, so the replacement string *must* be the
+# same length as the original. In the below replacements sequence, if the replacement string is
+# shorter than the match, it will be padded with spaces.
+
+
+import re, sys
+
+
+replacements = (
+    # Disable Electron sandbox enforcement in the ArgFilter
+    # (which looks for insecure command line options with a list of regexes)
+    (re.compile(re.escape(b'/no-sandbox/i,')), b''),
+)
+
+
+with open(sys.argv[1], 'r+b') as fp:
+    buf = bytearray(fp.read(2048))
+    used_replacements = set()
+
+    # Use a 1024-byte sliding window of the 2048-byte buffer to avoid potentially splitting
+    # the strings we're looking for over a buffer edge boundary.
+    # It's a bit inefficient but fast enough for this use case.
+    # We mostly just don't want to try to sort through the entire 60MB+ file in memory.
+
+    while True:
+        for i, (pattern, replacement) in enumerate(replacements):
+            for match in pattern.finditer(buf):
+                assert len(match.group()) >= len(replacement), (len(match.group()),
+                                                                len(replacement), match.group(),
+                                                                replacement)
+
+                replacement = replacement.ljust(len(match.group()))
+
+                pos = fp.tell()
+                fp.seek(pos - (2048 - match.start()))
+                fp.write(replacement)
+                fp.seek(pos)
+
+                buf[match.start():match.end()] = replacement
+                used_replacements.add(i)
+
+                break
+
+        chunk = fp.read(1024)
+        if not chunk:
+            break
+
+        del buf[:1024]
+        buf.extend(chunk)
+
+    if len(used_replacements) != len(replacements):
+        leftover_replacements = set(range(len(replacements))) - used_replacements
+        print('Leftover replacements:', file=sys.stderr)
+        for leftover_index in leftover_replacements:
+            pattern = replacements[leftover_index][0].pattern.decode()
+            print('', pattern, file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
As a temporary workaround for no upstream-supported way for Electron to
request nested sandboxes be created by Flatpak, use a version of
https://github.com/flathub/com.unity.UnityHub/blob/master/patch-resources.py
to patch the app resource file and remove the JavaScript code that makes
Skype exit if you pass --no-sandbox. After doing this, we can add
--no-sandbox to our launch script and run newer versions of Skype inside
a Flatpak sandbox. Works around #70 for now.