### PR TITLE
Register application menu in KDE

### DIFF
--- a/com.skype.Client.json
+++ b/com.skype.Client.json
@@ -23,7 +23,8 @@
         "--talk-name=org.freedesktop.Notifications",
         "--talk-name=org.gnome.GConf",
         "--env=XDG_CURRENT_DESKTOP=Unity",
-        "--talk-name=org.kde.StatusNotifierWatcher"
+        "--talk-name=org.kde.StatusNotifierWatcher",
+        "--talk-name=com.canonical.AppMenu.Registrar"
     ],
     "modules": [
         "shared-modules/libsecret/libsecret.json",


### PR DESCRIPTION
Currently, the application doesn't register the menu into my desktop environment, so I added an additional finish-arg as it was stated in [Octave issue](https://github.com/flathub/org.octave.Octave/issues/6)