### PR TITLE
Update icons

### DIFF
--- a/com.skype.Client.appdata.xml
+++ b/com.skype.Client.appdata.xml
@@ -22,8 +22,8 @@
     <category>Network</category>
   </categories>
   <!-- These are the icons for the android apps, from https://play.google.com/store/apps/details?id=com.skype.raider -->
-  <icon type="remote" height="64" width="64">https://lh3.googleusercontent.com/QfAEt_ya6-n8w_TD9-PsghFC2DMSO7fLGNZB4cQ3RtbBbHFkXJE_gxOc3l32-j6LXg=w64</icon>
-  <icon type="remote" height="128" width="128">https://lh3.googleusercontent.com/QfAEt_ya6-n8w_TD9-PsghFC2DMSO7fLGNZB4cQ3RtbBbHFkXJE_gxOc3l32-j6LXg=w128</icon>
+  <icon type="remote" height="64" width="64">https://play-lh.googleusercontent.com/-Udh2Qv4FyhP2uLfvNy27jzzXrrIfnDEi9kUqzhy8OQgGUcWXXud6nlg8UywECiRmME=w64</icon>
+  <icon type="remote" height="128" width="128">https://play-lh.googleusercontent.com/-Udh2Qv4FyhP2uLfvNy27jzzXrrIfnDEi9kUqzhy8OQgGUcWXXud6nlg8UywECiRmME=w128</icon>
   <releases>
     <release version="8.69.0.77" date="2021-02-16"/>
     <release version="8.68.0.100" date="2021-02-01"/>


### PR DESCRIPTION
Upstream has change its icons some time ago, and the ones presented by this package when using AppStream are out of date.

This PR updates these icons.

Fixes #120