### PR TITLE
Add 256 and 512 resolution icons

### DIFF
--- a/com.skype.Client.appdata.xml
+++ b/com.skype.Client.appdata.xml
@@ -24,6 +24,8 @@
   <!-- These are the icons for the android apps, from https://play.google.com/store/apps/details?id=com.skype.raider -->
   <icon type="remote" height="64" width="64">https://lh3.googleusercontent.com/QfAEt_ya6-n8w_TD9-PsghFC2DMSO7fLGNZB4cQ3RtbBbHFkXJE_gxOc3l32-j6LXg=w64</icon>
   <icon type="remote" height="128" width="128">https://lh3.googleusercontent.com/QfAEt_ya6-n8w_TD9-PsghFC2DMSO7fLGNZB4cQ3RtbBbHFkXJE_gxOc3l32-j6LXg=w128</icon>
+  <icon type="remote" height="256" width="256">https://lh3.googleusercontent.com/QfAEt_ya6-n8w_TD9-PsghFC2DMSO7fLGNZB4cQ3RtbBbHFkXJE_gxOc3l32-j6LXg=w256</icon>
+  <icon type="remote" height="512" width="512">https://lh3.googleusercontent.com/QfAEt_ya6-n8w_TD9-PsghFC2DMSO7fLGNZB4cQ3RtbBbHFkXJE_gxOc3l32-j6LXg=w512</icon>
   <releases>
     <release version="8.95.0.408" date="2023-03-16"/>
     <release version="8.94.0.428" date="2023-02-28"/>


### PR DESCRIPTION
The icon is available up to 512x512, this makes them visible to Flathub. Currently the icon on Flathub is extremely small because those are missing.

![image](https://user-images.githubusercontent.com/13943260/225712808-6a89741c-0c90-4fa6-94d4-4f4e629f01a4.png)
