### PR TITLE
restore commit 9e738aa

### DIFF
--- a/com.skype.Client.json
+++ b/com.skype.Client.json
@@ -107,8 +107,8 @@
                     "type": "extra-data",
                     "filename": "skypeforlinux-64.deb",
                     "url": "https://repo.skype.com/deb/pool/main/s/skypeforlinux/skypeforlinux_8.100.0.203_amd64.deb",
-                    "sha256": "f6349089c2650b38a66d134d9ca383b79f39c5209f98ea93a09f6f92a2e64d3f",
-                    "size": 126350240,
+                    "sha256": "74dfabbc23cda0d52ffbd893ced693e30e15e6b420e5cb4cede7b50d787dbcde",
+                    "size": 126350190,
                     "only-arches": [
                         "x86_64"
                     ],


### PR DESCRIPTION
It seems that the package provided by MS servers changed and then rolled back without any correlating changelog or version change. This PR intends to restore the commit 9e738aa, which now has the correct extra data (sha256sum fingerprint and payload size) for the package provided by Microsoft.