### PR TITLE
Update com.skype.Client.desktop for wayland-compatibility

### DIFF
--- a/com.skype.Client.desktop
+++ b/com.skype.Client.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Skype
 Comment=Skype Internet Telephony
-Exec=/app/bin/skype %U
+Exec=/app/bin/skype --enable-features=UseOzonePlatform,WaylandWindowDecorations --ozone-platform-hint=auto -enable-wayland-ime %U
 Icon=com.skype.Client
 Terminal=false
 Type=Application


### PR DESCRIPTION
added `--enable-features=UseOzonePlatform,WaylandWindowDecorations --ozone-platform-hint=auto -enable-wayland-ime` to the parameters passed to /app/bin/skype.

Would have added that in /app/bin/skype directly as it's just a zypak-wrapper starter script but alas it is part of the snap package so not possible to commit changes via MR to it.